### PR TITLE
Fix V3025

### DIFF
--- a/CSharpGL/Scene/SceneNodes/PickableNode/PickableNode.IPickable/Pickers/OneIndexPicker/OneIndexPicker.GetLastIndexId.cs
+++ b/CSharpGL/Scene/SceneNodes/PickableNode/PickableNode.IPickable/Pickers/OneIndexPicker/OneIndexPicker.GetLastIndexId.cs
@@ -112,7 +112,7 @@ namespace CSharpGL
                 recognizedPrimitiveIndex0.VertexIds.Length
                 + 1
                 + recognizedPrimitiveIndex1.VertexIds.Length)
-            { throw new Exception(string.Format("index array[{0}] not same length with [recognized primitive1 index length{1}] + [1] + recognized primitive2 index length[{2}]", recognizedPrimitiveIndex0.VertexIds.Length, recognizedPrimitiveIndex1.VertexIds.Length)); }
+            { throw new Exception(string.Format("index array[{0}] not same length with [recognized primitive1 index length{1}] + [1] + recognized primitive2 index length[{2}]", indexArray.Count, recognizedPrimitiveIndex0.VertexIds.Length, recognizedPrimitiveIndex1.VertexIds.Length)); }
 
             oneIndexBuffer = indexArray.ToArray().GenIndexBuffer(drawMode, BufferUsage.StaticDraw);
             //oneIndexBuffer = Buffer.Create(IndexElementType.UInt,


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

 - Incorrect format. A different number of format items is expected while calling 'Format' function. Format items not used: {2}. CSharpGL OneIndexPicker.GetLastIndexId.cs 115