### PR TITLE
Fix V3025

### DIFF
--- a/Infrastructure/CSharpGL.Models/SimpleObjFileFormat/PartParsers/Quad2TriangleParser.cs
+++ b/Infrastructure/CSharpGL.Models/SimpleObjFileFormat/PartParsers/Quad2TriangleParser.cs
@@ -25,7 +25,7 @@ namespace CSharpGL
                 if (normalIndexes.Length != vertexIndexes.Length)
                 {
                     throw new Exception(string.Format(
-                        "normalIndexes.Length [{0}] != vertexIndexes.Length [{0}]!",
+                        "normalIndexes.Length [{0}] != vertexIndexes.Length [{1}]!",
                     normalIndexes.Length, vertexIndexes.Length));
                 }
 


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: vertexIndexes.Length. CSharpGL.Models Quad2TriangleParser.cs 27