### PR TITLE
Fix V3025

### DIFF
--- a/Infrastructure/CSharpGL.Models/SimpleObjFileFormat/PartParsers/TexCoordParser.cs
+++ b/Infrastructure/CSharpGL.Models/SimpleObjFileFormat/PartParsers/TexCoordParser.cs
@@ -30,7 +30,7 @@ namespace CSharpGL
                 if (texCoordIndexes.Length != vertexIndexes.Length)
                 {
                     throw new Exception(string.Format(
-                        "normalIndexes.Length [{0}] != vertexIndexes.Length [{0}]!",
+                        "texCoordIndexes.Length [{0}] != vertexIndexes.Length [{1}]!",
                     texCoordIndexes.Length, vertexIndexes.Length));
                 }
 


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: vertexIndexes.Length. CSharpGL.Models TexCoordParser.cs 32