### PR TITLE
Fixed from PVS-Studio Static Analyzer

### DIFF
--- a/CSharpGL/Scene/SceneNodes/PickableNode/PickableNode.IPickable/Pickers/OneIndexPicker/OneIndexPicker.cs
+++ b/CSharpGL/Scene/SceneNodes/PickableNode/PickableNode.IPickable/Pickers/OneIndexPicker/OneIndexPicker.cs
@@ -37,7 +37,7 @@ namespace CSharpGL
             if (lastIndexId == null)
             {
                 Debug.WriteLine(string.Format(
-                    "Got lastVertexId[{0}] but no lastIndexId! Params are [{1}] [{2}] [{3}] [{4}]",
+                    "Got lastVertexId[{0}] but no lastIndexId! Params are [{1}] [{2}]",
                     lastVertexId, arg, stageVertexId));
                 { return null; }
             }


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

Incorrect format. A different number of format items is expected while calling 'Format' function. Format items not used: {3}, {4}. CSharpGL OneIndexPicker.cs 39